### PR TITLE
Replace "attribute" with "model" in most places

### DIFF
--- a/quickstart.md
+++ b/quickstart.md
@@ -33,7 +33,7 @@
 
     ```shell
     $ curl -H "Content-Type: application/json" --data \
-        '{comment: {text: "what kind of idiot name is foo?"}, 
+        '{comment: {text: "what kind of idiot name is foo?"},
           languages: ["en"],
           requestedAttributes: {TOXICITY:{}} }' \
         https://commentanalyzer.googleapis.com/v1alpha1/comments:analyze?key=YOUR_KEY_HERE
@@ -53,12 +53,19 @@
     ```
 
     The curl command issued an API request to analyze the `comment.text` field
-    for the `requestedAttributes`, in this case `TOXICITY`.
+    for the `requestedAttributes`, in this case the `TOXICITY` model.
 
     In the response ,the field `attributeScores.TOXICITY.summaryScore.value`
-    gives the API's "toxicity" score for the comment. In this case, the comment
+    gives the toxicity model's score for the comment. In this case, the comment
     got a 0.9 out of 1.0. A less mean-spirited comment should get a lower score.
 
-See the [API reference documentation](api_reference.md) for details on all of the request and response fields, as well as the available values for `requestedAttributes`.
-In particular, there are quite a few different [experimental attributes](https://github.com/conversationai/perspectiveapi/blob/master/api_reference.md#attributes), such as obscene, attack on a commenter, spam, etc.
-Add yourself to our [perspectiveapi-announce@ Google Group](https://groups.google.com/forum/#!forum/perspective-announce/join) to get updates when we add new models to make changes to the API.
+See the [API reference documentation](api_reference.md) for details on all of
+the request and response fields, as well as the available values for
+`requestedAttributes`. There are quite a few
+[experimental models](https://github.com/conversationai/perspectiveapi/blob/master/api_reference.md#models),
+such as "obscene", "attack on a commenter", "spam", etc, that you may find
+interesting.
+
+Also, subscribe to our
+[perspectiveapi-announce@ Google Group](https://groups.google.com/forum/#!forum/perspective-announce/join) to
+get notified when we make changes to the API.


### PR DESCRIPTION
In some places this change is somewhat awkward because the API fields use the word "attribute" (viz. requestedAttributes, attributeScores).