### PR TITLE
Recommend proxying request to protect API key

### DIFF
--- a/quickstart.md
+++ b/quickstart.md
@@ -10,7 +10,7 @@
     
 4.  **Generate an API key.** To authenticate your requests, you'll need to generate credentials for your project. Using an API key is the simplest option. Go to the [API credentials page](https://console.developers.google.com/apis/credentials), click **_Create credentials_**, and choose "API Key".
 
-    *Warning*: If you make requests from a client-side language like JavaScript, your API key will be exposed to all visitors. It's strongly recommended that you [add key restrictions](https://cloud.google.com/docs/authentication/api-keys#api_key_restrictions) so that only your production server can use that key.
+    *Warning*: If you make requests from a client-side language like JavaScript, your API key will be exposed to all visitors. It's strongly recommended that you [proxy the request through a server](https://github.com/conversationai/perspectiveapi-proxy), so that the key is hidden from browsers. Adding restrictions to the key in the Cloud console will not work, because the requests will come from arbitrary IP addresses, and the referer headers can be spoofed by abusers. Proxying the request is the only way to protect the key.
     
     Note that it typically takes only a few minutes for a new API key to have access after the API is enabled, but it can on occasion take up to an hour; until the API key is enabled, you may get errors of the form "API Key not found. Please pass a valid API key".
 


### PR DESCRIPTION
I was wrong in #59, API key restrictions will not sufficient to protect the key in this situation. They can either be easily defeated (in the case of referers), or will prevent the application from working (in the case of IP addresses). Proxying the request through a private server seems like the only proper way to protect the key.