### PR TITLE
Content clarity

### DIFF
--- a/1-get-started/README.md
+++ b/1-get-started/README.md
@@ -2,9 +2,11 @@
 
 # Get started with Perspective API
 
+Perspective API uses machine learning models to score the perceived impact a comment might have on a conversation. Developers and publishers can use this score to give realtime feedback to commenters or help moderators do their job, or allow readers to more easily find relevant information.
+
 ## Prerequisites
 
-You'll need a Google Cloud project to authenticate (but not necessarily host) your API requests. Go to the [Google Cloud console](https://console.developers.google.com/) and either use an existing project, or follow these steps to create a new one:
+You need a Google Cloud project to authenticate (but not necessarily host) your API requests. Go to the [Google Cloud console](https://console.developers.google.com/) and use an existing project or follow these steps to create a new one:
 
 1. Sign in with your Google account, if necessary.
 

--- a/1-get-started/support.md
+++ b/1-get-started/support.md
@@ -4,7 +4,9 @@
 
 For support and to contact us, visit [support.perspectiveapi.com](https://support.perspectiveapi.com/s/contactsupport). 
 
-If you would like to receive email updates about the API&mdash;for example when we add new models, or deprecate old ones&mdash;you can subscribe to the [perspective-announce Google Group](https://groups.google.com/forum/#!forum/perspective-announce/join). You will receive email updates from perspective-announce@googlegroups.com. This list will be used only to share release information and will never be used to ask you login details of any kind.
+If you would like to receive email updates about the API&mdash;for example when we add new models, or deprecate old ones&mdash;you can [subscribe to the perspective-announce Google Group](https://groups.google.com/forum/#!forum/perspective-announce/join). You will receive email updates from perspective-announce@googlegroups.com.
+
+The "persepctive-announce" list will be used only to share release information and will never be used to ask you login details of any kind.
 
 ## Get started
 

--- a/2-api/README.md
+++ b/2-api/README.md
@@ -5,8 +5,8 @@
 Read more about the Perspective API and how to use it.
 
 * [Key concepts](key-concepts.md)
-* [Models and attributes](models.md)
-   * [Model cards](model-cards/README.md)
+* [Attributes](models.md)
+   * [Attribute cards](model-cards/README.md)
 * [Methods](methods.md)
    * [Scoring comments](methods.md#scoring-comments-analyzecomment)
    * [Sending feedback](methods.md#sending-feedback-suggestcommentscore)

--- a/2-api/README.md
+++ b/2-api/README.md
@@ -6,7 +6,7 @@ Read more about the Perspective API and how to use it.
 
 * [Key concepts](key-concepts.md)
 * [Attributes](models.md)
-   * [Attribute cards](model-cards/README.md)
+   * [Model cards](model-cards/README.md)
 * [Methods](methods.md)
    * [Scoring comments](methods.md#scoring-comments-analyzecomment)
    * [Sending feedback](methods.md#sending-feedback-suggestcommentscore)

--- a/2-api/clients.md
+++ b/2-api/clients.md
@@ -123,8 +123,8 @@ See the docs [on the project's GitHub page](https://github.com/sloria/perspectiv
 Read more about the Perspective API and how to use it.
 
 * [Key concepts](key-concepts.md)
-* [Models and attributes](models.md)
-   * [Model cards](model-cards/README.md)
+* [Attributes](models.md)
+   * [Attribute cards](model-cards/README.md)
 * [Methods](methods.md)
    * [Scoring comments](methods.md#scoring-comments-analyzecomment)
    * [Sending feedback](methods.md#sending-feedback-suggestcommentscore)

--- a/2-api/key-concepts.md
+++ b/2-api/key-concepts.md
@@ -27,11 +27,23 @@ comment text, such as when determining the "off-topic" model score.
 are not making use of it. At this time, sending context won't change a model's
 scores.
 
+## Method
+
+A **method** is a procedure associating a message (or request) with an
+object (which consists of data and behavior). A method request will return
+a new object.
+
+For example, the [`AnalyzeComment` method](methods.md#scoring-comments-analyzecomment)
+sends a request to score the comment object. The comment object includes
+comment text, context, and more. The method then return the attribute span
+scores.
+
 ## Model
 
-A **model** is a collection of attributes for scoring a comment. For example,
-the Toxicty model contains attributes such as "Toxcity", "Profanity",
-"Fliratation", and more.
+A **model** is a collection of attributes for scoring a comment.
+
+For example, the Toxicty model contains attributes such as "Toxcity",
+"Profanity", "Fliratation", and more.
 
 ### Score types
 

--- a/2-api/key-concepts.md
+++ b/2-api/key-concepts.md
@@ -2,12 +2,13 @@
 
 # Key concepts
 
-To best understand the reference documentation, you must first understand these key concepts.
+To best understand the reference documentation, you must first understand these
+key concepts.
 
 ## Attribute
 
-An **attribute** is a comment label used for review. The most popular
-attributes are the toxicity and severe toxicity models.
+An **attribute** or **model attribute** is a comment label used for review.
+The most popular attribute is "toxicity".
 
 ## Comment
 
@@ -17,7 +18,7 @@ a forum post, a message to a mailing list, a chat message, etc.
 
 ## Context (coming soon)
 
-*(Coming soon)* **Context** is a representation of the conversation context
+_(Coming soon)_ **Context** is a representation of the conversation context
 for the comment, such as an article that is being commented on, or another
 comment that is being replied to. It is used in the analysis of the
 comment text, such as when determining the "off-topic" model score.
@@ -28,9 +29,9 @@ scores.
 
 ## Model
 
-A **model** is a dimension that the comment is scored on; for example,
-"toxic," "obscene," "thoughtful," "off-topic," etc. This is also sometimes 
-referred to as an **attribute** or **model attribute**.
+A **model** is a collection of attributes for scoring a comment. For example,
+the Toxicty model contains attributes such as "Toxcity", "Profanity",
+"Fliratation", and more.
 
 ### Score types
 
@@ -41,15 +42,12 @@ of the attribute label.
 
 ## Span
 
-A **span** is a continuous section of text. The API can return **span scores**, which are
-model scores for particular subparts of the request's comment. For example, if the API only
-found one sentence in a paragraph to be "toxic," it could return a high "toxic" span score
-for the span corresponding to that sentence, while giving a low "toxic" span score to the
-rest of the comment.
+A **span** is a continuous section of text. The API can return span scores,
+which are model scores for particular subparts of the request's comment.
 
 ### Span scores
 
-A **span score** is a model score for subparts of the request's comment.
+A **span score** is a score type for subparts of the request's comment.
 
 For example, if the API only found one sentence in a paragraph to be "toxic",
 it could return a high "toxic" span score for the span corresponding to that

--- a/2-api/key-concepts.md
+++ b/2-api/key-concepts.md
@@ -10,6 +10,8 @@ key concepts.
 An **attribute** or **model attribute** is a comment label used for review.
 The most popular attribute is "toxicity".
 
+This was previously known also as "model".
+
 ## Comment
 
 A **comment** is the text to be scored. Each API request contains a single
@@ -38,12 +40,6 @@ sends a request to score the comment object. The comment object includes
 comment text, context, and more. The method then return the attribute span
 scores.
 
-## Model
-
-A **model** is a collection of attributes for scoring a comment.
-
-For example, the Toxicty model contains attributes such as "Toxcity",
-"Profanity", "Fliratation", and more.
 
 ### Score types
 

--- a/2-api/key-concepts.md
+++ b/2-api/key-concepts.md
@@ -8,7 +8,7 @@ key concepts.
 ## Attribute
 
 An **attribute** is a comment label used for review. The most popular attribute
-is "toxicity".
+is `TOXICITY`.
 
 This was previously known also as "model".
 
@@ -23,11 +23,11 @@ a forum post, a message to a mailing list, a chat message, etc.
 _(Coming soon)_ **Context** is a representation of the conversation context
 for the comment, such as an article that is being commented on, or another
 comment that is being replied to. It is used in the analysis of the
-comment text, such as when determining the "off-topic" model score.
+comment text, such as when determining the `OFF_TOPIC` model score.
 
 **Note**: you can send context with your requests, however our current models
-are not making use of it. At this time, sending context won't change a model's
-scores.
+are not making use of it. At this time, sending context won't change an
+attribute's scores.
 
 ## Method
 
@@ -40,10 +40,9 @@ sends a request to score the comment object. The comment object includes
 comment text, context, and more. The method then return the attribute span
 scores.
 
-
 ### Score types
 
-**Score types** are different formats for the API to return model attribute
+**Score types** are different formats for the API to return attribute
 scores. Currently, the only score type supported is the probability score
 type with a value between 0 and 1. Higher values indicating greater likelihood
 of the attribute label.
@@ -51,7 +50,7 @@ of the attribute label.
 ## Span
 
 A **span** is a continuous section of text. The API can return span scores,
-which are model scores for particular subparts of the request's comment.
+which are attribute scores for particular subparts of the request's comment.
 
 ### Span scores
 
@@ -60,17 +59,17 @@ A **span score** is a score type for subparts of the request's comment.
 For example, if the API only found one sentence in a paragraph to be "toxic",
 it could return a high "toxic" span score for the span corresponding to that
 sentence while giving a low "toxic" span score to the rest of the comment.
-This score is only available for some models.
+This score is only available for some attributes.
 
 ### Summary Score
 
-A model's **summary score** provides an overall score for the entire comment.
-While the API may return multiple span scores for a given input, it will
-always return exactly one summary score.
+An attribute's **summary score** provides an overall score for the entire
+comment. While the API may return multiple span scores for a given input, it
+will always return exactly one summary score.
 
-## Toxicity
+## `TOXICITY`
 
-**Toxicity** is an attribute which Perspective can score. Toxicity is defined
+**`TOXICITY`** is an attribute which Perspective can score. `TOXICITY` is defined
 as "a rude, disrespectful, or unreasonable comment that is likely to make you
 leave a discussion."
 

--- a/2-api/key-concepts.md
+++ b/2-api/key-concepts.md
@@ -10,7 +10,13 @@ key concepts.
 An **attribute** is a comment label used for review. The most popular attribute
 is `TOXICITY`.
 
-This was previously known also as "model".
+Attribute was previously known as "model". 
+
+#### Why did we make this name change?
+
+Machine Learning is a fast-moving discipline, with a lot of community-driven and historical terminalogy. It's our believe that the community has rough consensus on the term "machine learning model (ML model)". This term artifact, a neural net architecture together with the weights that result from training that neural net, defines something that can take inputs ("features") and produce outputs (class labels, regression scores, sometimes known as targets). Models generally can produce multiple outputs.
+
+Our current API design chooses to expose each of these outputs as a separate name. We call the outputs attributes.
 
 ## Comment
 

--- a/2-api/key-concepts.md
+++ b/2-api/key-concepts.md
@@ -16,7 +16,7 @@ Attribute was previously known as "model".
 
 Machine Learning is a fast-moving discipline, with a lot of community-driven and historical terminalogy. It's our believe that the community has rough consensus on the term "machine learning model (ML model)". This term artifact, a neural net architecture together with the weights that result from training that neural net, defines something that can take inputs ("features") and produce outputs (class labels, regression scores, sometimes known as targets). Models generally can produce multiple outputs.
 
-Our current API design chooses to expose each of these outputs as a separate name. We call the outputs attributes.
+Our current API design chooses to expose each of these outputs as a separate name. We call these outputs "attributes".
 
 ## Comment
 

--- a/2-api/key-concepts.md
+++ b/2-api/key-concepts.md
@@ -14,7 +14,7 @@ Attribute was previously known as "model".
 
 #### Why did we make this name change?
 
-Machine Learning is a fast-moving discipline, with a lot of community-driven and historical terminalogy. It's our believe that the community has rough consensus on the term "machine learning model (ML model)". This term artifact, a neural net architecture together with the weights that result from training that neural net, defines something that can take inputs ("features") and produce outputs (class labels, regression scores, sometimes known as targets). Models generally can produce multiple outputs.
+Machine Learning is a fast-moving discipline, with a lot of community-driven and historical terminalogy. It's our belief that the community has rough consensus on the term "machine learning model (ML model)". This term, meaning a neural net architecture together with the weights that result from training that neural net, defines something that can take inputs ("features") and produce outputs (class labels, regression scores, sometimes known as targets). Models generally can produce multiple outputs.
 
 Our current API design chooses to expose each of these outputs as a separate name. We call these outputs "attributes".
 

--- a/2-api/key-concepts.md
+++ b/2-api/key-concepts.md
@@ -2,11 +2,12 @@
 
 # Key concepts
 
-To best understand the reference documentation, you must first know these key concepts.
+To best understand the reference documentation, you must first understand these key concepts.
 
 ## Attribute
 
-A comment label used for review. The most popular attributes are the toxicity and severe toxicity models.
+An **attribute** is a comment label used for review. The most popular
+attributes are the toxicity and severe toxicity models.
 
 ## Comment
 
@@ -14,24 +15,29 @@ A **comment** is the text to be scored. Each API request contains a single
 comment. A comment could be a single post to a web page's comments section,
 a forum post, a message to a mailing list, a chat message, etc.
 
+## Context (coming soon)
+
+*(Coming soon)* **Context** is a representation of the conversation context
+for the comment, such as an article that is being commented on, or another
+comment that is being replied to. It is used in the analysis of the
+comment text, such as when determining the "off-topic" model score.
+
+**Note**: you can send context with your requests, however our current models
+are not making use of it. At this time, sending context won't change a model's
+scores.
+
 ## Model
 
- A **model** is a dimension that the comment is scored on; for example,
- "toxic," "obscene," "thoughtful," "off-topic," etc. This is also sometimes referred to
- as an **attribute** or **model attribute**.
+A **model** is a dimension that the comment is scored on; for example,
+"toxic," "obscene," "thoughtful," "off-topic," etc. This is also sometimes 
+referred to as an **attribute** or **model attribute**.
 
-### Model attribute scores
+### Score types
 
-The API can return **model attribute scores** in different formats, known as
-**score types**. Currently, the only score type supported is a probability score
-between 0 and 1, with higher values indicating greater likelihood of the attribute
-label.
-
-### Summary Score
-
-A model's **summary score** provides an overall score for the entire
-comment. While the API may return multiple span scores for a given input, it
-will always return exactly one summary score.
+**Score types** are different formats for the API to return model attribute
+scores. Currently, the only score type supported is the probability score
+type with a value between 0 and 1. Higher values indicating greater likelihood
+of the attribute label.
 
 ## Span
 
@@ -43,23 +49,24 @@ rest of the comment.
 
 ### Span scores
 
-Model scores for particular subparts of the request's comment. For example, if the API only found one sentence in a paragraph to be "toxic", it could return a high "toxic" span score for the span corresponding to that sentence while giving a low "toxic" span score to the rest of the comment. This score is only available for some models.
+A **span score** is a model score for subparts of the request's comment.
 
-## Context
+For example, if the API only found one sentence in a paragraph to be "toxic",
+it could return a high "toxic" span score for the span corresponding to that
+sentence while giving a low "toxic" span score to the rest of the comment.
+This score is only available for some models.
 
-*(Coming soon)* **Context** is a representation of the conversation context
-for the comment; for example, an article that is being commented on, or
-another comment that is being replied to. It is used in the analysis of the
-comment text; for example, when determining the "off-topic" model score.
+### Summary Score
 
-**Note**: you can send context with your requests, however our current models
-are not making use of it&mdash;so sending context won't change any model's
-scores.
+A model's **summary score** provides an overall score for the entire comment.
+While the API may return multiple span scores for a given input, it will
+always return exactly one summary score.
 
 ## Toxicity
 
-One of the attributes that Perspective can score. Toxicity is defined as "a rude,
-disrespectful, or unreasonable comment that is likely to make you leave a discussion."
+**Toxicity** is an attribute which Perspective can score. Toxicity is defined
+as "a rude, disrespectful, or unreasonable comment that is likely to make you
+leave a discussion."
 
 ## All reference materials
 

--- a/2-api/key-concepts.md
+++ b/2-api/key-concepts.md
@@ -7,8 +7,8 @@ key concepts.
 
 ## Attribute
 
-An **attribute** or **model attribute** is a comment label used for review.
-The most popular attribute is "toxicity".
+An **attribute** is a comment label used for review. The most popular attribute
+is "toxicity".
 
 This was previously known also as "model".
 
@@ -79,7 +79,7 @@ leave a discussion."
 Read more about the Perspective API and how to use it.
 
 * **Key concepts**
-* [Models and attributes](models.md)
+* [Attributes](models.md)
    * [Model cards](model-cards/README.md)
 * [Methods](methods.md)
    * [Scoring comments](methods.md#scoring-comments-analyzecomment)

--- a/2-api/key-concepts.md
+++ b/2-api/key-concepts.md
@@ -25,9 +25,9 @@ for the comment, such as an article that is being commented on, or another
 comment that is being replied to. It is used in the analysis of the
 comment text, such as when determining the `OFF_TOPIC` model score.
 
-**Note**: you can send context with your requests, however our current models
-are not making use of it. At this time, sending context won't change an
-attribute's scores.
+**Note**: you can send context with your requests, however our current
+attributes are not making use of it. At this time, sending context won't
+change an attribute's scores.
 
 ## Method
 

--- a/2-api/limits.md
+++ b/2-api/limits.md
@@ -24,8 +24,8 @@ The maximum text size per request is 3000 bytes.
 Read more about the Perspective API and how to use it.
 
 * [Key concepts](key-concepts.md)
-* [Models and attributes](models.md)
-   * [Model cards](model-cards/README.md)
+* [Attributes](models.md)
+   * [Attribute cards](model-cards/README.md)
 * [Methods](methods.md)
    * [Scoring comments](methods.md#scoring-comments-analyzecomment)
    * [Sending feedback](methods.md#sending-feedback-suggestcommentscore)

--- a/2-api/limits.md
+++ b/2-api/limits.md
@@ -2,6 +2,10 @@
 
 # Limits and errors
 
+The Perspective API uses limits and quotas to protect the system from receiving more data than it can handle, and to ensure equitable distribution of the system resources. These limits and quotas are subject to change.
+
+You may encounter an error if the quota of your request exceeds the limit.
+
 ## Quota limit
 
 By default, we set the quota to 1 QPS for all Perspective projects.

--- a/2-api/limits.md
+++ b/2-api/limits.md
@@ -4,7 +4,7 @@
 
 The Perspective API uses limits and quotas to protect the system from receiving more data than it can handle, and to ensure equitable distribution of the system resources. These limits and quotas are subject to change.
 
-You may encounter an error if the quota of your request exceeds the limit.
+You may encounter an error if your request exceeds the limit.
 
 ## Quota limit
 

--- a/2-api/limits.md
+++ b/2-api/limits.md
@@ -25,7 +25,7 @@ Read more about the Perspective API and how to use it.
 
 * [Key concepts](key-concepts.md)
 * [Attributes](models.md)
-   * [Attribute cards](model-cards/README.md)
+   * [Model cards](model-cards/README.md)
 * [Methods](methods.md)
    * [Scoring comments](methods.md#scoring-comments-analyzecomment)
    * [Sending feedback](methods.md#sending-feedback-suggestcommentscore)

--- a/2-api/limits.md
+++ b/2-api/limits.md
@@ -8,7 +8,7 @@ You may encounter an error if your request exceeds the limit.
 
 ## Quota limit
 
-By default, we set the quota to 1 QPS for all Perspective projects.
+By default, we set the quota to 1 query per second (QPS) for all Perspective projects.
 
 Check your quota limits by going to [your Google Cloud project's Perspective API page](https://console.cloud.google.com/apis/api/commentanalyzer.googleapis.com/quotas), and check your project's quota usage at
 [the cloud console quota usage page](https://console.cloud.google.com/iam-admin/quotas).

--- a/2-api/methods.md
+++ b/2-api/methods.md
@@ -270,8 +270,8 @@ The response is not particularly interesting:
 Read more about the Perspective API and how to use it.
 
 * [Key concepts](key-concepts.md)
-* [Models and attributes](models.md)
-   * [Model cards](model-cards/README.md)
+* [Attributes](models.md)
+   * [Attribute cards](model-cards/README.md)
 * **Methods**
    * [Scoring comments](methods.md#scoring-comments-analyzecomment)
    * [Sending feedback](methods.md#sending-feedback-suggestcommentscore)

--- a/2-api/methods.md
+++ b/2-api/methods.md
@@ -53,15 +53,15 @@ If you're using API key authentication, append `?key=YOUR_API_KEY` to the end of
 | `context.entries` | *(optional)* A list of objects providing the context for `comment`. Currently not supported by the API. |
 | `context.entries[].text` | *(optional)* The text of a context object. The maximum size of context entry is 1MB. |
 | `context.entries[].type` | *(optional)* The text type of the corresponding context text. Same type as `comment.text`. Currently only `"PLAIN TEXT"` is supported. |
-| `requestedAttributes`    | **(required)** A map from model's attribute name to a configuration object. See the [models section](#all-model-types) for a list of available model attribute names. If no configuration options are specified, defaults are used, so the empty object `{}` is a valid (and common) choice. You can specify multiple model names here to get scores from multiple models in a single request. |
-| `requestedAttributes[name].scoreType` | *(optional)* The score type returned for this model attribute. Currently, only `"PROBABILITY"` is supported. Probability scores are in the range `[0,1]`. |
-| `requestedAttributes[name].scoreThreshold` | *(optional)* The API won't return scores that are below this threshold for this model attribute. By default, all scores are returned. |
+| `requestedAttributes`    | **(required)** A map from attribute name to a configuration object. See the [attributes section](models.md#all-attribute-types) for a list of available attribute names. If no configuration options are specified, defaults are used, so the empty object `{}` is a valid (and common) choice. You can specify multiple attribute names here to get scores from multiple attributes in a single request. |
+| `requestedAttributes[name].scoreType` | *(optional)* The score type returned for this attribute. Currently, only `"PROBABILITY"` is supported. Probability scores are in the range `[0,1]`. |
+| `requestedAttributes[name].scoreThreshold` | *(optional)* The API won't return scores that are below this threshold for this attribute. By default, all scores are returned. |
 | `spanAnnotations` | *(optional)* A boolean value that indicates if the request should return spans that describe the scores for each part of the text (currently done at per-sentence level). Defaults to false. |
-| `languages` | *(optional)* A list of [ISO 631-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) two-letter language codes specifying the language(s) that `comment` is in (for example, `"en"`, `"es"`, `"fr"`, `"de"`, etc). If unspecified, the API will auto-detect the comment language. If language detection fails, the API returns an error. **Note:** Currently, all production models only support English, Spanish, and French. There is no simple way to use the API across languages with production support and languages with experimental support only. |
-| `doNotStore` | *(optional)* Whether the API is permitted to store `comment` and `context` from this request. Stored comments will be used for future research and community model building purposes to improve the API over time. We also plan to provide dashboards and automated analysis of the comments submitted, which will apply only to those stored. Defaults to false (request data may be stored). **Warning**: This should be set to true if data being submitted is private (i.e. not publicly accessible), or if the data submitted contains content written by someone under 13 years old. |
+| `languages` | *(optional)* A list of [ISO 631-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) two-letter language codes specifying the language(s) that `comment` is in (for example, `"en"`, `"es"`, `"fr"`, `"de"`, etc). If unspecified, the API will auto-detect the comment language. If language detection fails, the API returns an error. **Note:** Currently, all production attributes only support English, Spanish, and French. There is no simple way to use the API across languages with production support and languages with experimental support only. |
+| `doNotStore` | *(optional)* Whether the API is permitted to store `comment` and `context` from this request. Stored comments will be used for future research and community attribute building purposes to improve the API over time. We also plan to provide dashboards and automated analysis of the comments submitted, which will apply only to those stored. Defaults to false (request data may be stored). **Warning**: This should be set to true if data being submitted is private (i.e. not publicly accessible), or if the data submitted contains content written by someone under 13 years old. |
 | `clientToken` | *(optional)* An opaque token that is echoed back in the response. |
-| `sessionId` | *(optional)* An opaque session id. This should be set for authorship experiences by the client side so that groups of requests can be grouped together into a session. This should not be used for any user-specific id. This is intended for abuse protection and individual sessions of interaction. |
-| `suggestCommentScore` | *(optional)* Used to notify the Perspective API team of specific biases, in order to help us improve our model. Many kinds of toxic language are disproportionately represented in our dataset, which leads to some obviously incorrect scores, as well as unintended biases. Use this method to help us correct them. |
+| `sessionId` | *(optional)* An opaque session ID. This should be set for authorship experiences by the client side so that groups of requests can be grouped together into a session. This should not be used for any user-specific id. This is intended for abuse protection and individual sessions of interaction. |
+| `suggestCommentScore` | *(optional)* Used to notify the Perspective API team of specific biases, in order to help us improve our attribute. Many kinds of toxic language are disproportionately represented in our dataset, which leads to some obviously incorrect scores, as well as unintended biases. Use this method to help us correct them. |
 
 Note that only `comment.text` and `requestedAttributes` are required.
 
@@ -92,8 +92,8 @@ Note that only `comment.text` and `requestedAttributes` are required.
 
 | Field | Description |
 | ----- | ----------- |
-| `attributeScores` | A map from model attribute name to per-attribute score objects. The attribute names will mirror the request's `requestedAttributes`.
-| `attributeScores[name].summaryScore.value` | The model attribute summary score for the entire comment. All attributes will return a `summaryScore` (unless the request specified a `scoreThreshold` for the attribute that the `summaryScore` did not exceed). |
+| `attributeScores` | A map from attribute name to per-attribute score objects. The attribute names will mirror the request's `requestedAttributes`.
+| `attributeScores[name].summaryScore.value` | The attribute summary score for the entire comment. All attributes will return a `summaryScore` (unless the request specified a `scoreThreshold` for the attribute that the `summaryScore` did not exceed). |
 | `attributeScores[name].summaryScore.type` | This mirrors the requested `scoreType` for this attribute. |
 | `attributeScores[name].spanScores` | A list of per-span scores for this attribute. These scores apply to different parts of the request's `comment.text`. **Note:** Some attributes may not return `spanScores` at all. |
 | `attributeScores[name].spanScores[].begin` | Beginning of the text span in the request comment. |
@@ -105,7 +105,7 @@ Note that only `comment.text` and `requestedAttributes` are required.
 
 ### `AnalyzeComment` example
 
-This is a request for the `TOXICITY` and `UNSUBSTANTIAL` models for a comment that's explicitly in English.
+This is a request for the `TOXICITY` and `UNSUBSTANTIAL` attributes for a comment that's explicitly in English.
 
 ```json
 // Request
@@ -121,9 +121,9 @@ This is a request for the `TOXICITY` and `UNSUBSTANTIAL` models for a comment th
 }
 ```
  
-The response contains the `TOXICITY` and `UNSUBSTANTIAL` model scores. Each attribute has a single overall `summaryScore` as well as two `spanScores`.
+The response contains the `TOXICITY` and `UNSUBSTANTIAL` attribute scores. Each attribute has a single overall `summaryScore` as well as two `spanScores`.
 
-Both models return the same spans in this case: the span `[0,31)` (corresponding to "What kind of idiot name is foo?") and the span `[32,56)` (corresponding to "Sorry, I like your name."). However, models may not always return the same spans.
+Both attributes return the same spans in this case: the span `[0,31)` (corresponding to "What kind of idiot name is foo?") and the span `[32,56)` (corresponding to "Sorry, I like your name."). However, attributes may not always return the same spans.
 
 ```json
 // Response
@@ -170,7 +170,7 @@ Both models return the same spans in this case: the span `[0,31)` (corresponding
 
 The `SuggestCommentScore` endpoints submits feedback to the API in the form of a
 suggested score. You can use this method if you disagree with a score and would
-like to improve the model. All submissions to `SuggestCommentScore` are stored
+like to improve the attribute. All submissions to `SuggestCommentScore` are stored
 and used to improve the API and related services. This method should **not** be
 used for private data (i.e., for data that is not accessible publicly), or if the
 data submitted contains content written by someone under 13 years old.

--- a/2-api/methods.md
+++ b/2-api/methods.md
@@ -271,7 +271,7 @@ Read more about the Perspective API and how to use it.
 
 * [Key concepts](key-concepts.md)
 * [Attributes](models.md)
-   * [Attribute cards](model-cards/README.md)
+   * [Model cards](model-cards/README.md)
 * **Methods**
    * [Scoring comments](methods.md#scoring-comments-analyzecomment)
    * [Sending feedback](methods.md#sending-feedback-suggestcommentscore)

--- a/2-api/methods.md
+++ b/2-api/methods.md
@@ -2,7 +2,9 @@
 
 # API Methods
 
-There are two API methods: 
+A method is a procedure associating a message (or request) with an object (which consists of data and behavior). Once run, a method returns a new object.
+
+There are two methods available for Perspective API: 
 
 + [`AnalyzeComment`](#scoring-comments-analyzecomment)
 + [`SuggestCommentScore`](#sending-feedback-suggestcommentscore)
@@ -15,7 +17,7 @@ To send a comment scoring request to the API, post a request object to this endp
 https://commentanalyzer.googleapis.com/v1alpha1/comments:analyze
 ```
 
-If you're using API key authentication, append `?key=YOUR_API_KEY` to the end of the request. See the [quickstart guide](quickstart.md) for an example.
+If you're using API key authentication, append `?key=YOUR_API_KEY` to the end of the request. See the [get started guide](../1-get-started/README.md) for an example.
 
 ### `AnalyzeComment` request
 

--- a/2-api/methods.md
+++ b/2-api/methods.md
@@ -4,10 +4,10 @@
 
 A method is a procedure associating a message (or request) with an object (which consists of data and behavior). Once run, a method returns a new object.
 
-There are two methods available for Perspective API: 
+There are two methods available for Perspective API, where each method is a different type of request a user can send:
 
-+ [`AnalyzeComment`](#scoring-comments-analyzecomment)
-+ [`SuggestCommentScore`](#sending-feedback-suggestcommentscore)
++ [`AnalyzeComment`](#scoring-comments-analyzecomment), where a user sends a request for a comment to be analyzed, and a score is returned
++ [`SuggestCommentScore`](#sending-feedback-suggestcommentscore), where a user can suggest a better score fora comment
 
 ## Scoring comments: `AnalyzeComment`
 

--- a/2-api/methods.md
+++ b/2-api/methods.md
@@ -7,7 +7,7 @@ A method is a procedure associating a message (or request) with an object (which
 There are two methods available for Perspective API, where each method is a different type of request a user can send:
 
 + [`AnalyzeComment`](#scoring-comments-analyzecomment), where a user sends a request for a comment to be analyzed, and a score is returned
-+ [`SuggestCommentScore`](#sending-feedback-suggestcommentscore), where a user can suggest a better score fora comment
++ [`SuggestCommentScore`](#sending-feedback-suggestcommentscore), where a user can suggest a better score for a comment
 
 ## Scoring comments: `AnalyzeComment`
 

--- a/2-api/model-cards/README.md
+++ b/2-api/model-cards/README.md
@@ -1,4 +1,4 @@
-[Perspective API documentation](../../README.md) >  [API Reference Docs](../README.md) > [Production and experimental models](../models.md) > **Model Cards**
+[Perspective API documentation](../../README.md) >  [API Reference Docs](../README.md) > [Attributes](../models.md) > **Attribute Cards**
 
 # Perspective API Model Cards
 

--- a/2-api/model-cards/README.md
+++ b/2-api/model-cards/README.md
@@ -1,4 +1,4 @@
-[Perspective API documentation](../../README.md) >  [API Reference Docs](../README.md) > [Attributes](../models.md) > **Attribute Cards**
+[Perspective API documentation](../../README.md) >  [API Reference Docs](../README.md) > [Attributes](../models.md) > **Model Cards**
 
 # Perspective API Model Cards
 
@@ -18,7 +18,7 @@ See our [TOXICITY model card](English/toxicity.md) and our [model card blog post
 Read more about the Perspective API and how to use it.
 
 * [Key concepts](../key-concepts.md)
-* [PModels and attributes](../models.md)
+* [Attributes](../models.md)
    * **Model cards**
 * [Methods](../methods.md)
    * [Scoring comments](../methods.md#scoring-comments-analyzecomment)

--- a/2-api/models.md
+++ b/2-api/models.md
@@ -96,11 +96,11 @@ These attributes are experimental because they are trained on a single source of
 
 Most of our attributes are [Convolutional Neural Network](https://en.wikipedia.org/wiki/Convolutional_neural_network) (CNN) trained with [word-vector](https://www.tensorflow.org/tutorials/word2vec) inputs. You can also train your own [deep CNN for text classification](http://www.wildml.com/2015/12/implementing-a-cnn-for-text-classification-in-tensorflow/) on our [public toxicity dataset](https://figshare.com/articles/Wikipedia_Talk_Labels_Toxicity/4563973), and explore our [open-source attribute training tools](https://github.com/conversationai/conversationai-models) to train your own attributes. Our [Toxicity Kaggle Competition](https://kaggle.com/c/jigsaw-toxic-comment-classification-challenge) also has lots of useful resources to help build your own attributes.
 
-## Attribute cards
+## Model cards
 
-For each production attribute, we aim to publish an associated "Attribute card" that shares details about intended usage, attribute training processes, and evaluation results.
+For each production attribute, we aim to publish an associated "Model card" that shares details about intended usage, attribute training processes, and evaluation results.
 
-[View the current attribute cards](model-cards/README.md).
+[View the current model cards](model-cards/README.md).
 
 ## All reference materials
 

--- a/2-api/models.md
+++ b/2-api/models.md
@@ -2,7 +2,7 @@
 
 # Attributes
 
-An attribute (sometimes called "model attributes" or "models") is a label on which a comment is scored. For example, the some attributes scored by Perspective API include as "Toxcity", "Profanity", "Fliratation", and more. [See all attribute types](#all-attribute-types). Attributes can be in-production or experimental.
+An attribute (sometimes called "models") is a label on which a comment is scored. For example, the some attributes scored by Perspective API include as "Toxcity", "Profanity", "Fliratation", and more. [See all attribute types](#all-attribute-types). Attributes can be in-production or experimental.
 
 [Join the perspective-announce email group](https://groups.google.com/forum/#!forum/perspective-announce) to stay in the loop on important information about new attributes, updates to existing attributes, and deprecations.
 
@@ -44,7 +44,7 @@ Currently, Perspective API has production `TOXICITY` and `SEVERE_TOXICITY` attri
 + Spanish (es)
 + French (fr)
 
-### Experimental models for other language(s)
+### Experimental attributes for other language(s)
 
 Developing Perspective API's attributes for production takes some time. We are actively working on expanding to more languages in production. The following languages are those that are still being developed for production but ready for experimental use:
 
@@ -62,7 +62,7 @@ Only use the above attribute(s) if you are interested in testing an experimental
 | -------------------- | ---- | ----------- | -------- | -------------- |
 | `TOXICITY` | prod. | Rude, disrespectful, or unreasonable comment that is likely to make people leave a discussion. | en, fr, es | 6 |
 | `TOXICITY_EXPERIMENTAL` | exp. | &nbsp; | de, it, pt | &nbsp; |
-| `SEVERE_TOXICITY` | prod. | A very hateful, aggressive, disrespectful comment or otherwise very likely to make a user leave a discussion or give up on sharing their perspective. This attribute is much less sensitive to comments that include positive uses of curse words, for example. A labelled dataset and details of the methodology can be found in the same toxicity dataset that is available for the toxicity model. | en, fr, es | 2 |
+| `SEVERE_TOXICITY` | prod. | A very hateful, aggressive, disrespectful comment or otherwise very likely to make a user leave a discussion or give up on sharing their perspective. This attribute is much less sensitive to comments that include positive uses of curse words, for example. A labelled dataset and details of the methodology can be found in the same toxicity dataset that is available for the toxicity attribute. | en, fr, es | 2 |
 | `SEVERE_TOXICITY_EXPERIMENTAL` | exp. | &nbsp; | de, it, pt | &nbsp; |
 | `TOXICITY_FAST` | exp. | This attribute is similar to `TOXICITY`, but has lower latency and lower accuracy in its predictions. Unlike `TOXICITY`, this attribute returns summary scores as well as span scores. This attribute uses character-level n-grams fed into a logistic regression, a method that has been surprisingly effective at detecting abusive language. | en | &nbsp; |
 | `IDENTITY_ATTACK` | exp. | Negative or hateful comments targeting someone because of their identity. | en | 2 |
@@ -94,7 +94,7 @@ These attributes are experimental because they are trained on a single source of
 
 ## Attribute architecture
 
-Most of our attributes are [Convolutional Neural Network](https://en.wikipedia.org/wiki/Convolutional_neural_network) (CNN) trained with [word-vector](https://www.tensorflow.org/tutorials/word2vec) inputs. You can also train your own [deep CNN for text classification](http://www.wildml.com/2015/12/implementing-a-cnn-for-text-classification-in-tensorflow/) on our [public toxicity dataset](https://figshare.com/articles/Wikipedia_Talk_Labels_Toxicity/4563973), and explore our [open-source attribute training tools](https://github.com/conversationai/conversationai-models) to train your own attributes. Our [Toxicity Kaggle Competition](https://kaggle.com/c/jigsaw-toxic-comment-classification-challenge) also has lots of useful resources to help build your own models.
+Most of our attributes are [Convolutional Neural Network](https://en.wikipedia.org/wiki/Convolutional_neural_network) (CNN) trained with [word-vector](https://www.tensorflow.org/tutorials/word2vec) inputs. You can also train your own [deep CNN for text classification](http://www.wildml.com/2015/12/implementing-a-cnn-for-text-classification-in-tensorflow/) on our [public toxicity dataset](https://figshare.com/articles/Wikipedia_Talk_Labels_Toxicity/4563973), and explore our [open-source attribute training tools](https://github.com/conversationai/conversationai-models) to train your own attributes. Our [Toxicity Kaggle Competition](https://kaggle.com/c/jigsaw-toxic-comment-classification-challenge) also has lots of useful resources to help build your own attributes.
 
 ## Attribute cards
 
@@ -108,7 +108,7 @@ Read more about the Perspective API and how to use it.
 
 * [Key concepts](key-concepts.md)
 * **Attributes**
-   * [Attribute cards](model-cards/README.md)
+   * [Model cards](model-cards/README.md)
 * [Methods](methods.md)
    * [Scoring comments](methods.md#scoring-comments-analyzecomment)
    * [Sending feedback](methods.md#sending-feedback-suggestcommentscore)

--- a/2-api/models.md
+++ b/2-api/models.md
@@ -1,10 +1,10 @@
-[Perspective API documentation](../README.md) > [API Reference Docs](README.md) > **Models and attributes**
+[Perspective API documentation](../README.md) > [API Reference Docs](README.md) > **Attributes**
 
 # Attributes
 
 An attribute (sometimes called "model attributes" or "models") is a label on which a comment is scored. For example, the some attributes scored by Perspective API include as "Toxcity", "Profanity", "Fliratation", and more. [See all attribute types](#all-attribute-types). Attributes can be in-production or experimental.
 
-[Join the perspective-announce email group](https://groups.google.com/forum/#!forum/perspective-announce) to stay in the loop on important information about new attributes, updates to existing attributes, and deprecations. 
+[Join the perspective-announce email group](https://groups.google.com/forum/#!forum/perspective-announce) to stay in the loop on important information about new attributes, updates to existing attributes, and deprecations.
 
 ## Production attributes
 

--- a/2-api/models.md
+++ b/2-api/models.md
@@ -2,35 +2,39 @@
 
 # Models and attributes
 
-This section details Perspective API’s production and experimental models, which are described in detail in the [All model types](#all-model-types) table below.
+A model is a set of attributes (sometimes called "model attributes") on which a comment is scored on. For example, the Toxicity model contains attributes such as "Toxcity", "Profanity", "Fliratation", and more. [See all model types](#all-model-types). Models can be in-production or experimental.
 
-We recommend subscribing to [perspective-announce email group](https://groups.google.com/forum/#!forum/perspective-announce) to stay in the loop on important information about new models, updates to existing models, and deprecations. 
+[Join the perspective-announce email group](https://groups.google.com/forum/#!forum/perspective-announce) to stay in the loop on important information about new models, updates to existing models, and deprecations. 
 
 ## Production models
 
-We recommend using production models for your API request. Production models have been tested across multiple domains and trained on hundreds of thousands of human-annotated comments.
+Production models have been tested across multiple domains and trained on hundreds of thousands of human-annotated comments.
+
+We recommend using production models for your API requests.
 
 ## Experimental models
 
-We recommend reserving experimental models for non-production use cases. These models have not been tested as thoroughly as production models, and you’ll need to update your code when a model changes from experimental to production. We typically give one month’s notice before deprecating experimental models.
+Experimental models have not been tested as thoroughly as production models. If using these models, you’ll need to update your code when a model changes from experimental to production. We typically give one month’s notice before deprecating experimental models.
+
+We recommend using experimental models only in non-production environments.
 
 ### Important notes on using experimental models
 
-Experimental versions will be deprecated. These models are experimental and will eventually stop working when the production versions are created, so you will need to update the model name you are calling when the final version is available.
+Experimental models will be deprecated. Once deprecated and once production versions of these models are created, the experimental model will stop working. If that happens, you will need to update the API call's model name to the new production model name.
 
-Experimental versions will make even more mistakes than production models. They may not have been tested for issues including unintended bias and thus it is particularly important that they only be used in contexts where you have a human in the loop to identify and correct errors.
+Experimental versions will make even more mistakes than production models. They may not have been tested for issues, such as unintended bias, and thus it is particularly important that they only be used where a human is tasked with indentifying and correcting errors.
 
 ## Latest versions
 
 We retrain models and release new versions periodically. To call a specific version of a model, use the format `MODEL_NAME@VERSION_NUMBER` in the `requestedAttributes` field.
 
-If a request does not specify a `@VERSION_NUMBER` at the end of a model name, it uses the default version, which is often, but not always, the latest version of the model.
+If a request does not specify a `@VERSION_NUMBER` at the end of a model name, it uses the default version, which is often (but not always) the latest version of the model.
  
-View the latest version numbers in the [All model types](#all-model-types) table below.
+View the latest version numbers in the [All model types table](#all-model-types).
 
 ## Specifying language
 
-See the `languages` field description in the [Methods](#api-methods) section below to learn about how to specify language in your request. If you are using a production model, language is autodetected if not specified in the request.
+See the `languages` field description in the [Methods](#api-methods) section to learn about how to specify language in your request. If you are using a production model, language is autodetected if not specified in the request.
 
 ### Languages in production 
 

--- a/2-api/models.md
+++ b/2-api/models.md
@@ -1,44 +1,44 @@
 [Perspective API documentation](../README.md) > [API Reference Docs](README.md) > **Models and attributes**
 
-# Models and attributes
+# Attributes
 
-A model is a set of attributes (sometimes called "model attributes") on which a comment is scored on. For example, the Toxicity model contains attributes such as "Toxcity", "Profanity", "Fliratation", and more. [See all model types](#all-model-types). Models can be in-production or experimental.
+An attribute (sometimes called "model attributes" or "models") is a label on which a comment is scored. For example, the some attributes scored by Perspective API include as "Toxcity", "Profanity", "Fliratation", and more. [See all attribute types](#all-attribute-types). Attributes can be in-production or experimental.
 
-[Join the perspective-announce email group](https://groups.google.com/forum/#!forum/perspective-announce) to stay in the loop on important information about new models, updates to existing models, and deprecations. 
+[Join the perspective-announce email group](https://groups.google.com/forum/#!forum/perspective-announce) to stay in the loop on important information about new attributes, updates to existing attributes, and deprecations. 
 
-## Production models
+## Production attributes
 
-Production models have been tested across multiple domains and trained on hundreds of thousands of human-annotated comments.
+Production attributes have been tested across multiple domains and trained on hundreds of thousands of human-annotated comments.
 
-We recommend using production models for your API requests.
+We recommend using production attributes for your API requests.
 
-## Experimental models
+## Experimental attributes
 
-Experimental models have not been tested as thoroughly as production models. If using these models, you’ll need to update your code when a model changes from experimental to production. We typically give one month’s notice before deprecating experimental models.
+Experimental attributes have not been tested as thoroughly as production attributes. If using these attributes, you’ll need to update your code when an attribute changes from experimental to production. We typically give one month’s notice before deprecating experimental attributes.
 
-We recommend using experimental models only in non-production environments.
+We recommend using experimental attributes only in non-production environments.
 
-### Important notes on using experimental models
+### Important notes on using experimental attributes
 
-Once experimental models are deprecated and production versions of these models are created, the experimental model will stop working. If that happens, you will need to update the API call's model name to the new production model name.
+Once experimental attributes are deprecated and production versions of these attributes are created, the experimental attribute will stop working. If that happens, you will need to update the API call's attribute name to the new production attribute name.
 
-Experimental versions will make even more mistakes than production models. They may not have been tested for issues, such as unintended bias. For these models in particular, we strongly recommend a human be tasked with identifying and correcting errors.
+Experimental versions will make even more mistakes than production attributes. They may not have been tested for issues, such as unintended bias. For these attributes in particular, we strongly recommend a human be tasked with identifying and correcting errors.
 
 ## Latest versions
 
-We retrain models and release new versions periodically. To call a specific version of a model, use the format `MODEL_NAME@VERSION_NUMBER` in the `requestedAttributes` field.
+We retrain attributes and release new versions periodically. To call a specific version of an attribute, use the format `ATTRIBUTE_NAME@VERSION_NUMBER` in the `requestedAttributes` field.
 
-If a request does not specify a `@VERSION_NUMBER` at the end of a model name, it uses the default version, which is often (but not always) the latest version of the model.
+If a request does not specify a `@VERSION_NUMBER` at the end of an attribute name, it uses the default version, which is often (but not always) the latest version of the attribute.
  
-View the latest version numbers in the [All model types table](#all-model-types).
+View the latest version numbers in the [All attribute types table](#all-attribute-types).
 
 ## Specifying language
 
-See the `languages` field description in the [Methods](#api-methods) section to learn about how to specify language in your request. If you are using a production model, language is autodetected if not specified in the request.
+See the `languages` field description in the [Methods](#api-methods) section to learn about how to specify language in your request. If you are using a production attribute, language is auto-detected if not specified in the request.
 
 ### Languages in production 
 
-Currently, Perspective API has production `TOXICITY` and `SEVERE_TOXICITY` models in the following languages:
+Currently, Perspective API has production `TOXICITY` and `SEVERE_TOXICITY` attributes in the following languages:
 
 + English (en)
 + Spanish (es)
@@ -46,27 +46,25 @@ Currently, Perspective API has production `TOXICITY` and `SEVERE_TOXICITY` model
 
 ### Experimental models for other language(s)
 
-Developing Perspective API's models for production takes some time. We are actively working on expanding to more languages in production. The following languages are those that are still being developed for production but ready for experimental use:
+Developing Perspective API's attributes for production takes some time. We are actively working on expanding to more languages in production. The following languages are those that are still being developed for production but ready for experimental use:
 
 + German (de)
 + Portuguese (pt)
 + Italian (it)
 
-Only use the above model(s) if you are interested in testing an experimental model and are willing to change your code once the production models are available. If you are not sure, please wait until a production version is ready which we will announce via perspective-announce@.
+Only use the above attribute(s) if you are interested in testing an experimental attribute and are willing to change your code once the production attributes are available. If you are not sure, please wait until a production version is ready which we will announce via perspective-announce@.
 
-If you wish to test new experimental models please refer to [model reference](/api/models.md). 
+## All attribute types
 
-## All model types
-
-### Toxicity models
+### Toxicity attributes
  
-| Model attribute name | Type | Description | Language | Latest version |
+| Attribute name | Type | Description | Language | Latest version |
 | -------------------- | ---- | ----------- | -------- | -------------- |
 | `TOXICITY` | prod. | Rude, disrespectful, or unreasonable comment that is likely to make people leave a discussion. | en, fr, es | 6 |
 | `TOXICITY_EXPERIMENTAL` | exp. | &nbsp; | de, it, pt | &nbsp; |
-| `SEVERE_TOXICITY` | prod. | A very hateful, aggressive, disrespectful comment or otherwise very likely to make a user leave a discussion or give up on sharing their perspective. This model is much less sensitive to comments that include positive uses of curse words, for example. A labelled dataset and details of the methodology can be found in the same toxicity dataset that is available for the toxicity model. | en, fr, es | 2 |
+| `SEVERE_TOXICITY` | prod. | A very hateful, aggressive, disrespectful comment or otherwise very likely to make a user leave a discussion or give up on sharing their perspective. This attribute is much less sensitive to comments that include positive uses of curse words, for example. A labelled dataset and details of the methodology can be found in the same toxicity dataset that is available for the toxicity model. | en, fr, es | 2 |
 | `SEVERE_TOXICITY_EXPERIMENTAL` | exp. | &nbsp; | de, it, pt | &nbsp; |
-| `TOXICITY_FAST` | exp. | This model is similar to the `TOXICITY` model, but has lower latency and lower accuracy in its predictions. Unlike `TOXICITY`, this model returns summary scores as well as span scores. This model uses character-level n-grams fed into a logistic regression, a method that has been surprisingly effective at detecting abusive language. | en | &nbsp; |
+| `TOXICITY_FAST` | exp. | This attribute is similar to `TOXICITY`, but has lower latency and lower accuracy in its predictions. Unlike `TOXICITY`, this attribute returns summary scores as well as span scores. This attribute uses character-level n-grams fed into a logistic regression, a method that has been surprisingly effective at detecting abusive language. | en | &nbsp; |
 | `IDENTITY_ATTACK` | exp. | Negative or hateful comments targeting someone because of their identity. | en | 2 |
 | `IDENTITY_ATTACK_EXPERIMENTAL` | exp. | &nbsp; | fr, de, es, it, pt | &nbsp; |
 | `INSULT` | exp. | Insulting, inflammatory, or negative comment towards a person or a group of people. | en | 2 |
@@ -78,11 +76,11 @@ If you wish to test new experimental models please refer to [model reference](/a
 | `SEXUALLY_EXPLICIT` | exp. |Contains references to sexual acts, body parts, or other lewd content. | en | 2 |
 |`FLIRTATION` | exp. | Pickup lines, complimenting appearance, subtle sexual innuendos, etc. | en | 2 |
  
-### New York Times models
+### New York Times attributes
 
-These models are experimental because they are trained on a single source of comments&mdash;New York Times (NYT) data tagged by their moderation team&mdash;and therefore may not work well for every use case. 
+These attributes are experimental because they are trained on a single source of comments&mdash;New York Times (NYT) data tagged by their moderation team&mdash;and therefore may not work well for every use case. 
 
-| Model attribute name | Type | Description | Language | Latest version |
+| Attribute name | Type | Description | Language | Latest version |
 | -------------------- | ---- | ----------- | -------- | -------------- |
 | `ATTACK_ON_AUTHOR` | exp. | Attack on the author of an article or post. | en | 2 |
 | `ATTACK_ON_COMMENTER` | exp. | Attack on fellow commenter. | en | 2 |
@@ -94,23 +92,23 @@ These models are experimental because they are trained on a single source of com
 | `UNSUBSTANTIAL` | exp. | Trivial or short comments. | en | 2 |
 
 
-## Model architecture
+## Attribute architecture
 
-Most of our models are [Convolutional Neural Network](https://en.wikipedia.org/wiki/Convolutional_neural_network) (CNN) trained with [word-vector](https://www.tensorflow.org/tutorials/word2vec) inputs. You can also train your own [deep CNN for text classification](http://www.wildml.com/2015/12/implementing-a-cnn-for-text-classification-in-tensorflow/) on our [public toxicity dataset](https://figshare.com/articles/Wikipedia_Talk_Labels_Toxicity/4563973), and explore our [open-source model training tools](https://github.com/conversationai/conversationai-models) to train your own models. Our [Toxicity Kaggle Competition](https://kaggle.com/c/jigsaw-toxic-comment-classification-challenge) also has lots of useful resources to help build your own models.
+Most of our attributes are [Convolutional Neural Network](https://en.wikipedia.org/wiki/Convolutional_neural_network) (CNN) trained with [word-vector](https://www.tensorflow.org/tutorials/word2vec) inputs. You can also train your own [deep CNN for text classification](http://www.wildml.com/2015/12/implementing-a-cnn-for-text-classification-in-tensorflow/) on our [public toxicity dataset](https://figshare.com/articles/Wikipedia_Talk_Labels_Toxicity/4563973), and explore our [open-source attribute training tools](https://github.com/conversationai/conversationai-models) to train your own attributes. Our [Toxicity Kaggle Competition](https://kaggle.com/c/jigsaw-toxic-comment-classification-challenge) also has lots of useful resources to help build your own models.
 
-## Model Cards
+## Attribute cards
 
-For each production model, we aim to publish an associated "Model Card" that shares details about intended usage, model training processes, and evaluation results.
+For each production attribute, we aim to publish an associated "Attribute card" that shares details about intended usage, attribute training processes, and evaluation results.
 
-[View the current model cards](model-cards/README.md).
+[View the current attribute cards](model-cards/README.md).
 
 ## All reference materials
 
 Read more about the Perspective API and how to use it.
 
 * [Key concepts](key-concepts.md)
-* **Models and attributes**
-   * [Model cards](model-cards/README.md)
+* **Attributes**
+   * [Attribute cards](model-cards/README.md)
 * [Methods](methods.md)
    * [Scoring comments](methods.md#scoring-comments-analyzecomment)
    * [Sending feedback](methods.md#sending-feedback-suggestcommentscore)

--- a/2-api/models.md
+++ b/2-api/models.md
@@ -2,7 +2,7 @@
 
 # Attributes
 
-An attribute (sometimes called "models") is a label on which a comment is scored. For example, the some attributes scored by Perspective API include as "Toxcity", "Profanity", "Fliratation", and more. [See all attribute types](#all-attribute-types). Attributes can be in-production or experimental.
+An attribute (previously known as "models") is a label on which a comment is scored. For example, the some attributes scored by Perspective API include as `TOXICITY`, `PROFANITY`, `FLIRTATION`, and more. [See all attribute types](#all-attribute-types). Attributes can be in-production or experimental.
 
 [Join the perspective-announce email group](https://groups.google.com/forum/#!forum/perspective-announce) to stay in the loop on important information about new attributes, updates to existing attributes, and deprecations.
 

--- a/2-api/models.md
+++ b/2-api/models.md
@@ -20,9 +20,9 @@ We recommend using experimental models only in non-production environments.
 
 ### Important notes on using experimental models
 
-Experimental models will be deprecated. Once deprecated and once production versions of these models are created, the experimental model will stop working. If that happens, you will need to update the API call's model name to the new production model name.
+Once experimental models are deprecated and production versions of these models are created, the experimental model will stop working. If that happens, you will need to update the API call's model name to the new production model name.
 
-Experimental versions will make even more mistakes than production models. They may not have been tested for issues, such as unintended bias, and thus it is particularly important that they only be used where a human is tasked with indentifying and correcting errors.
+Experimental versions will make even more mistakes than production models. They may not have been tested for issues, such as unintended bias. For these models in particular, we strongly recommend a human be tasked with identifying and correcting errors.
 
 ## Latest versions
 

--- a/3-concepts/README.md
+++ b/3-concepts/README.md
@@ -2,9 +2,9 @@
 
 # Concepts
 
-## What is score normalization for?
+## Score normalization
 
-Score normalization of our models is intended to do two things:
+We use score normalization for our models, which is intended to do two things:
 
 *   Provide a way to interpret the scores of a model as a probability (e.g. how
     likely is it that the comment will be perceived as toxic).
@@ -13,4 +13,4 @@ Score normalization of our models is intended to do two things:
     thresholds they use each time our models are retrained with additional
     examples.
 
-[Read more](score-normalization.md)
+[Read more about score normalization](score-normalization.md)

--- a/3-concepts/README.md
+++ b/3-concepts/README.md
@@ -4,13 +4,14 @@
 
 ## Score normalization
 
-We use score normalization for our models, which is intended to do two things:
+We use score normalization for our attributes, which is intended to do two
+things:
 
-*   Provide a way to interpret the scores of a model as a probability (e.g. how
-    likely is it that the comment will be perceived as toxic).
-*   Enable models to be improved without any action needed by most clients,
-    Without normalization, clients using the model would have to change the
-    thresholds they use each time our models are retrained with additional
+*   Provide a way to interpret the scores of an attribute as a probability
+    (e.g. how likely is it that the comment will be perceived as toxic).
+*   Enable attributes to be improved without any action needed by most clients,
+    Without normalization, clients using the attribute would have to change the
+    thresholds they use each time our attributes are retrained with additional
     examples.
 
 [Read more about score normalization](score-normalization.md)

--- a/3-concepts/score-normalization.md
+++ b/3-concepts/score-normalization.md
@@ -2,8 +2,6 @@
 
 # Score normalization and feedback
 
-## What is score normalization for?
-
 Score normalization of our models is intended to do two things:
 
 *   Provide a way to interpret the scores of a model as a probability (e.g. how

--- a/3-concepts/score-normalization.md
+++ b/3-concepts/score-normalization.md
@@ -44,11 +44,11 @@ better ways to do this, please
 
 ## About score feedback
 
-Our attributes are not perfect and will make errors. It will be unable to
-detect patterns of toxicity it has not seen before, and it will falsely detect
-comments similar to patterns of previous toxic conversations. To help improve
-the machine learning, the API supports sending our team suggested scores and
-corrections.
+Our machine learning attributes are not perfect and will make errors. It will
+be unable to detect patterns of toxicity it has not seen before, and it will
+falsely detect comments similar to patterns of previous toxic conversations.
+To help improve the machine learning, the API supports sending our team
+suggested scores and corrections.
 
 ## Reporting issues with scores
  

--- a/3-concepts/score-normalization.md
+++ b/3-concepts/score-normalization.md
@@ -44,11 +44,11 @@ better ways to do this, please
 
 ## About score feedback
 
-Our machine learning attributes are not perfect and will make errors. It will
-be unable to detect patterns of toxicity it has not seen before, and it will
-falsely detect comments similar to patterns of previous toxic conversations.
-To help improve the machine learning, the API supports sending our team
-suggested scores and corrections.
+Our machine learning attributes are not perfect and will make errors. our
+attributes will be unable to detect patterns of toxicity it has not seen
+before, and it will falsely detect comments similar to patterns of previous
+toxic conversations. To help improve the machine learning, the API supports
+sending our team suggested scores and corrections.
 
 ## Reporting issues with scores
  

--- a/3-concepts/score-normalization.md
+++ b/3-concepts/score-normalization.md
@@ -2,23 +2,23 @@
 
 # Score normalization and feedback
 
-Score normalization of our models is intended to do two things:
+Score normalization of our attributes is intended to do two things:
 
-*   Provide a way to interpret the scores of a model as a probability (e.g. how
-    likely is it that the comment will be perceived as toxic).
-*   Enable models to be improved without any action needed by most clients,
-    Without normalization, clients using the model would have to change the
-    thresholds they use each time our models are retrained with additional
+*   Provide a way to interpret the scores of an attribute as a probability
+    (e.g. how likely is it that the comment will be perceived as toxic).
+*   Enable attributes to be improved without any action needed by most clients,
+    Without normalization, clients using the attribute would have to change the
+    thresholds they use each time our attributes are retrained with additional
     examples.
 
 
 ## When did score-normalizing start happening?
 
 *   [v1 of score normalization](/releases/score_normalization_v1.md) on 2017-06-13
-    introduced score normalization for all models.
+    introduced score normalization for all attributes.
 *   [v2 of score normalization](/releases/score_normalization_v2_for_toxicity.md) on
     2017-08-15: fixes will go live for our normalization of `TOXICITY` scores
-    (other models are not affected).
+    (other attributes are not affected).
 
 
 ## How is score normalization done?
@@ -30,7 +30,7 @@ of **0.80** can be interpreted as a belief that **80%** of people would consider
 the comment to be toxic.
 
 However, as we introduce additional data, the basic distribution of how many
-toxic comments there are can change. Because models are far from perfect, this
+toxic comments there are can change. Because attributes are far from perfect, this
 would result in a shift in the calibration scores. To control for this, we
 perform callibration on a randomly selected 50/50 class split. of course, this
 control is not perfect: if the newly introduced examples are differently
@@ -38,23 +38,23 @@ difficult to previous ones, some change in scores is still likely.
 However, in practice, we think this will be reasonably stable, and clients will
 be able to have the same 'sense' of what a threshold means.
 
-
 We are always looking for better ways to provide stability, so if you know of
 better ways to do this, please
 [open an issue on GitHub](https://github.com/conversationai/perspectiveapi/issues).
 
 ## About score feedback
 
-Our models are not perfect and will make errors. It will be unable to detect patterns
-of toxicity it has not seen before, and it will falsely detect comments similar to
-patterns of previous toxic conversations. To help improve the machine learning, the API
-supports sending our team suggested scores and corrections.
+Our attributes are not perfect and will make errors. It will be unable to
+detect patterns of toxicity it has not seen before, and it will falsely detect
+comments similar to patterns of previous toxic conversations. To help improve
+the machine learning, the API supports sending our team suggested scores and
+corrections.
 
 ## Reporting issues with scores
  
 ### Reporting via API
 
-To report feedback on model scores, submit feedback as a request to the API
+To report feedback on attribute scores, submit feedback as a request to the API
 using [`SuggestCommentScore`](api_reference.md#suggestcommentscore-request).
 
 Since all submissions are stored and used to improved the API, do not use this for private

--- a/5-contribute/label-data.md
+++ b/5-contribute/label-data.md
@@ -7,8 +7,8 @@ but you can also contribute data from your own community.
 
 ### Why contribute labeled data
 
-Submitting labeled data lets the Perspective API team train the models on more
-comments, and makes it possible for the API to improve and learn from your
+Submitting labeled data lets the Perspective API team train the attributes on
+more comments, and makes it possible for the API to improve and learn from your
 particular use-case.
 
 ### What types of datasets are useful?

--- a/5-contribute/label-data.md
+++ b/5-contribute/label-data.md
@@ -7,9 +7,9 @@ but you can also contribute data from your own community.
 
 ### Why contribute labeled data
 
-Submitting labeled data lets the Perspective API team train the attributes on
-more comments, and makes it possible for the API to improve and learn from your
-particular use-case.
+Submitting labeled data lets the Perspective API team train the model
+attributes on more comments, and makes it possible for the API to improve and
+learn from your particular use-case.
 
 ### What types of datasets are useful?
 

--- a/5-contribute/privacy.md
+++ b/5-contribute/privacy.md
@@ -6,6 +6,6 @@ The Conversation AI team takes your data and privacy very seriously, both in the
  
 When a developer submits a snippet of text to be scored, Perspective does not request or store any information about the author of the snippet.
 
-Developers have the option to have snippets stored by Perspective to improve future models, or can have the snippets automatically deleted after the score is returned by enabling the `doNotStore` option.
+Developers have the option to have snippets stored by Perspective to improve future attributes, or can have the snippets automatically deleted after the score is returned by enabling the `doNotStore` option.
 
 Our full privacy policy can be read on [Google's policy website](https://policies.google.com/privacy?hl=en).

--- a/6-contact/README.md
+++ b/6-contact/README.md
@@ -4,5 +4,5 @@
 
 For support and to contact us, visit [support.perspectiveapi.com](https://support.perspectiveapi.com/). 
 
-If you would like to receive email updates about the API&mdash;for example when we add new models, or deprecate old ones&mdash;you can subscribe to the [perspective-announce Google Group](https://groups.google.com/forum/#!forum/perspective-announce/join). You will receive email updates from perspective-announce@googlegroups.com. This list will be used only to share release information and will never be used to ask you login details of any kind.
+If you would like to receive email updates about the API&mdash;for example when we add new attributes, or deprecate old ones&mdash;you can subscribe to the [perspective-announce Google Group](https://groups.google.com/forum/#!forum/perspective-announce/join). You will receive email updates from perspective-announce@googlegroups.com. This list will be used only to share release information and will never be used to ask you login details of any kind.
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ This repository contains the necessary documentation to start using the Perspect
 1. [API Reference](2-api/)
    + [Key concepts](2-api/key-concepts.md)
    + [Clients](2-api/clients.md)
-   + [Models and attributes](2-api/models.md)
-      + [Model cards](2-api/model-cards/README.md)
+   + [Attributes](2-api/models.md)
+      + [Attribute cards](2-api/model-cards/README.md)
    + [Methods](2-api/methods.md)
    + [Limits and errors](2-api/limits.md)
 1. [Concepts](3-concepts/)
@@ -48,7 +48,7 @@ to submit corrections.
 
 ## About this project
 
-Perspective was created by Jigsaw and Google’s Counter Abuse Technology team in a collaborative research project called [Conversation-AI](https://conversationai.github.io/). We open source experiments, models, and research data to explore the strengths and weaknesses of ML as a tool for online discussion.
+Perspective was created by Jigsaw and Google’s Counter Abuse Technology team in a collaborative research project called [Conversation-AI](https://conversationai.github.io/). We open source experiments, attributes, and research data to explore the strengths and weaknesses of ML as a tool for online discussion.
 
 You can email your research-related questions to [conversationai-questions@google.com](mailto:conversationai-questions@google.com).
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This repository contains the necessary documentation to start using the Perspect
    + [Key concepts](2-api/key-concepts.md)
    + [Clients](2-api/clients.md)
    + [Attributes](2-api/models.md)
-      + [Attribute cards](2-api/model-cards/README.md)
+      + [Model cards](2-api/model-cards/README.md)
    + [Methods](2-api/methods.md)
    + [Limits and errors](2-api/limits.md)
 1. [Concepts](3-concepts/)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository contains the necessary documentation to start using the Perspect
    + [Sample requests](1-get-started/sample.md)
    + [Support](1-get-started/support.md)
 1. [API Reference](2-api/)
-   + [Key concepts](2-api/key-concepts)
+   + [Key concepts](2-api/key-concepts.md)
    + [Clients](2-api/clients.md)
    + [Models and attributes](2-api/models.md)
       + [Model cards](2-api/model-cards/README.md)

--- a/glossary.md
+++ b/glossary.md
@@ -6,28 +6,69 @@ These are the terms you must know to understand the Perspective API and document
 
 ### Attribute
 
-A comment label used for review. The most popular attributes are the toxicity and severe toxicity models.
+An **attribute** or **model attribute** is a comment label used for review.
+The most popular attribute is "toxicity".
+
+This was previously known also as "model".
 
 ### Comment
 
-The text to be scored. Each API request contains a single comment. A comment could be a single post to a web page's comments section, a forum post, a message to a mailing list, a chat message, etc.
+A **comment** is the text to be scored. Each API request contains a single
+comment. A comment could be a single post to a web page's comments section,
+a forum post, a message to a mailing list, a chat message, etc.
 
-### Model
+### Context (coming soon)
 
-A dimension that the comment is scored on, for example, "toxic", "obscene", "thoughtful", "off-topic", etc. This is also sometimes referred to as an attribute or model attribute. Models can be labeled `Prod`, meaning they are recommended for use, or experimental, meaning that they are still in development but are open for public use if you're comfortable using experimental, imperfect models. See our list of models here.
+_(Coming soon)_ **Context** is a representation of the conversation context
+for the comment, such as an article that is being commented on, or another
+comment that is being replied to. It is used in the analysis of the
+comment text, such as when determining the "off-topic" model score.
 
-### Model summary score
+**Note**: you can send context with your requests, however our current models
+are not making use of it. At this time, sending context won't change a model's
+scores.
 
-An overall score for the entire comment. While the API may return multiple span scores for a given input, it will always return exactly one summary score.
+### Method
+
+A **method** is a procedure associating a message (or request) with an
+object (which consists of data and behavior). A method request will return
+a new object.
+
+For example, the [`AnalyzeComment` method](methods.md#scoring-comments-analyzecomment)
+sends a request to score the comment object. The comment object includes
+comment text, context, and more. The method then return the attribute span
+scores.
+
+
+### Score types
+
+**Score types** are different formats for the API to return model attribute
+scores. Currently, the only score type supported is the probability score
+type with a value between 0 and 1. Higher values indicating greater likelihood
+of the attribute label.
 
 ### Span
 
-A continuous section of text.
+A **span** is a continuous section of text. The API can return span scores,
+which are model scores for particular subparts of the request's comment.
 
 ### Span scores
 
-Model scores for particular subparts of the request's comment. For example, if the API only found one sentence in a paragraph to be "toxic", it could return a high "toxic" span score for the span corresponding to that sentence while giving a low "toxic" span score to the rest of the comment. This score is only available for some models.
+A **span score** is a score type for subparts of the request's comment.
+
+For example, if the API only found one sentence in a paragraph to be "toxic",
+it could return a high "toxic" span score for the span corresponding to that
+sentence while giving a low "toxic" span score to the rest of the comment.
+This score is only available for some models.
+
+### Summary Score
+
+A model's **summary score** provides an overall score for the entire comment.
+While the API may return multiple span scores for a given input, it will
+always return exactly one summary score.
 
 ### Toxicity
 
-One of the attributes that Perspective can score. Toxicity is defined as "a rude, disrespectful, or unreasonable comment that is likely to make you leave a discussion."
+**Toxicity** is an attribute which Perspective can score. Toxicity is defined
+as "a rude, disrespectful, or unreasonable comment that is likely to make you
+leave a discussion."


### PR DESCRIPTION
This PR cleans up the content for clarity. This includes:

+ Defining the terms "attribute" and "method" for non-technical audiences
+ "Model" is now always known as "attribute" 
+ Clean up the key concepts list to clearly define the term and then give examples
+ Clarify the difference between a model and a model attribute
+ Define what a limit is and why it exists

I've also fixed a couple old / broken links.